### PR TITLE
Extract trace and artifact signals into run summaries

### DIFF
--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -1,12 +1,14 @@
 """Orchestrates benchmark runs serially across a list of models."""
 
 import asyncio
+import hashlib
 import json
 import logging
 import random
 import re
 import subprocess
 import time
+import tomllib
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -28,6 +30,29 @@ WORKSPACE_BASE = Path.home() / ".limerick-benchmark" / "workspaces"
 RUN_ORDER_CHOICES = ("balanced", "random", "fixed")
 _WORKSPACE_IGNORE_DIR_NAMES = {".venv", ".git", "__pycache__", "node_modules"}
 _WORKSPACE_IGNORE_PREFIXES = (".aider.",)
+_SELF_CORRECTION_PATTERNS = (
+    re.compile(r"\bfix(?:ed|ing)?\b", re.IGNORECASE),
+    re.compile(r"\bmistake\b", re.IGNORECASE),
+    re.compile(r"\bforgot\b", re.IGNORECASE),
+    re.compile(r"\bcorrection\b", re.IGNORECASE),
+    re.compile(r"\bretry(?:ing)?\b", re.IGNORECASE),
+)
+_VERIFICATION_PATTERNS = (
+    re.compile(r"\bverify(?:ing|ied)?\b", re.IGNORECASE),
+    re.compile(r"\bdouble-check(?:ing)?\b", re.IGNORECASE),
+    re.compile(r"\bcheck(?:ing)?\b", re.IGNORECASE),
+    re.compile(r"\bconfirm(?:ing|ed)?\b", re.IGNORECASE),
+    re.compile(r"\btest(?:ed|ing)?\b", re.IGNORECASE),
+)
+_FORMAT_FIXATION_PATTERNS = (
+    re.compile(r"edit format", re.IGNORECASE),
+    re.compile(r"whole edit format", re.IGNORECASE),
+    re.compile(r"edit-errors\.html", re.IGNORECASE),
+    re.compile(r"no filename provided before", re.IGNORECASE),
+    re.compile(r"\breflections allowed\b", re.IGNORECASE),
+)
+_INLINE_HTML_RE = re.compile(r"<(?:html|body|head|meta|script|style|pre|div|p)\b", re.IGNORECASE)
+_ROUTE_DECORATOR_RE = re.compile(r"@\w+\.route\(", re.IGNORECASE)
 
 
 def _slug(model_id: str) -> str:
@@ -103,6 +128,156 @@ def _first_meaningful_edit_seconds(workspace: Path, started_epoch_ns: int) -> fl
     if first_edit_ns is None:
         return None
     return _round_seconds(max(0.0, (first_edit_ns - started_epoch_ns) / 1_000_000_000))
+
+
+def _workspace_file_snapshot(workspace: Path) -> set[str]:
+    snapshot: set[str] = set()
+    if not workspace.exists():
+        return snapshot
+
+    for path in workspace.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            rel = path.relative_to(workspace)
+        except ValueError:
+            continue
+        if any(part in _WORKSPACE_IGNORE_DIR_NAMES for part in rel.parts):
+            continue
+        if any(part.startswith(_WORKSPACE_IGNORE_PREFIXES) for part in rel.parts):
+            continue
+        snapshot.add(rel.as_posix())
+    return snapshot
+
+
+def _count_pattern_matches(patterns: tuple[re.Pattern[str], ...], texts: list[str]) -> int:
+    return sum(len(pattern.findall(text)) for pattern in patterns for text in texts)
+
+
+def _trace_texts(trace_path: Path) -> tuple[int, int, list[str]]:
+    line_count = 0
+    assistant_answer_count = 0
+    texts: list[str] = []
+
+    if not trace_path.exists():
+        return line_count, assistant_answer_count, texts
+
+    with trace_path.open() as f:
+        for line in f:
+            line_count += 1
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            event_type = entry.get("type")
+            if event_type == "assistant":
+                content = entry.get("content")
+                if isinstance(content, str) and content.strip():
+                    assistant_answer_count += 1
+                    texts.append(content)
+            elif event_type == "aider_log":
+                content = entry.get("content")
+                if isinstance(content, str) and content.strip():
+                    texts.append(content)
+
+    return line_count, assistant_answer_count, texts
+
+
+def _collect_trace_signals(trace_path: Path) -> dict[str, Any]:
+    line_count, assistant_answer_count, texts = _trace_texts(trace_path)
+    duplicate_output_attempt_count = 0
+    seen_texts: set[str] = set()
+    for text in texts:
+        normalized = " ".join(text.lower().split())
+        if not normalized:
+            continue
+        if normalized in seen_texts:
+            duplicate_output_attempt_count += 1
+        else:
+            seen_texts.add(normalized)
+
+    return {
+        "trace_line_count": line_count,
+        "assistant_answer_count": assistant_answer_count,
+        "self_correction_marker_count": _count_pattern_matches(_SELF_CORRECTION_PATTERNS, texts),
+        "verification_marker_count": _count_pattern_matches(_VERIFICATION_PATTERNS, texts),
+        "format_fixation_marker_count": _count_pattern_matches(_FORMAT_FIXATION_PATTERNS, texts),
+        "duplicate_output_attempt_count": duplicate_output_attempt_count,
+    }
+
+
+def _dependency_count(workspace: Path) -> int:
+    pyproject = workspace / "pyproject.toml"
+    if not pyproject.exists():
+        return 0
+    try:
+        data = tomllib.loads(pyproject.read_text())
+    except (OSError, tomllib.TOMLDecodeError):
+        return 0
+    dependencies = data.get("project", {}).get("dependencies", [])
+    if not isinstance(dependencies, list):
+        return 0
+    return sum(1 for dep in dependencies if isinstance(dep, str) and dep.strip())
+
+
+def _app_py_signals(workspace: Path) -> dict[str, Any]:
+    app_path = workspace / "app.py"
+    if not app_path.exists():
+        return {
+            "app_py_sha256": None,
+            "app_py_bytes": None,
+            "app_py_loc": None,
+            "uses_render_template_string": False,
+            "uses_inline_html": False,
+            "route_count": 0,
+        }
+
+    try:
+        content = app_path.read_bytes()
+    except OSError:
+        return {
+            "app_py_sha256": None,
+            "app_py_bytes": None,
+            "app_py_loc": None,
+            "uses_render_template_string": False,
+            "uses_inline_html": False,
+            "route_count": 0,
+        }
+
+    text = content.decode("utf-8", errors="replace")
+    return {
+        "app_py_sha256": hashlib.sha256(content).hexdigest(),
+        "app_py_bytes": len(content),
+        "app_py_loc": sum(1 for line in text.splitlines() if line.strip()),
+        "uses_render_template_string": "render_template_string(" in text,
+        "uses_inline_html": bool(_INLINE_HTML_RE.search(text)),
+        "route_count": len(_ROUTE_DECORATOR_RE.findall(text)),
+    }
+
+
+def _collect_workspace_artifact_signals(
+    workspace: Path,
+    initial_snapshot: set[str],
+    started_epoch_ns: int,
+) -> dict[str, Any]:
+    current_snapshot = _workspace_file_snapshot(workspace)
+    modified_existing_count = 0
+    for rel_path in current_snapshot & initial_snapshot:
+        path = workspace / rel_path
+        try:
+            mtime_ns = path.stat().st_mtime_ns
+        except OSError:
+            continue
+        if mtime_ns >= started_epoch_ns:
+            modified_existing_count += 1
+
+    return {
+        "workspace_file_count": len(current_snapshot),
+        "files_created_count": len(current_snapshot - initial_snapshot),
+        "files_modified_count": modified_existing_count,
+        "dependency_count": _dependency_count(workspace),
+        **_app_py_signals(workspace),
+    }
 
 
 def _ordered_models_for_round(
@@ -361,6 +536,7 @@ async def _run_one(
     workspace = WORKSPACE_BASE / job_id / run_dir_name
     workspace.mkdir(parents=True)
     _prepare_workspace(workspace, task_name=task_name, agent_type=agent_type)
+    initial_workspace_snapshot = _workspace_file_snapshot(workspace)
 
     # Symlink for convenience so results dir is self-contained for browsing
     (run_dir / "workspace").symlink_to(workspace)
@@ -450,6 +626,12 @@ async def _run_one(
     collector.stop()
 
     normalized_agent_stats = _normalize_agent_stats_for_eval(agent_stats, eval_result)
+    trace_signals = _collect_trace_signals(run_dir / "trace.jsonl")
+    artifact_signals = _collect_workspace_artifact_signals(
+        workspace,
+        initial_workspace_snapshot,
+        run_started_epoch_ns,
+    )
 
     summary = {
         "model_id": model_id,
@@ -472,6 +654,8 @@ async def _run_one(
         "startup_seconds": eval_result.get("startup_seconds"),
         "timeout_seconds": timeout,
         "aider_stagnation_timeout_seconds": aider_stagnation_timeout,
+        **trace_signals,
+        **artifact_signals,
         **token_state,
         **normalized_agent_stats,
         "eval": eval_result,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,5 @@
 import json
+import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -8,6 +9,8 @@ from benchmark.runner import (
     RUN_ORDER_CHOICES,
     RESULTS_ROOT,
     _build_run_plan,
+    _collect_trace_signals,
+    _collect_workspace_artifact_signals,
     _first_meaningful_edit_seconds,
     _new_job_id,
     _normalize_agent_stats_for_eval,
@@ -18,6 +21,7 @@ from benchmark.runner import (
     _should_evaluate,
     _slug,
     _task_prompt_with_workspace_note,
+    _workspace_file_snapshot,
     run_benchmark,
 )
 
@@ -201,6 +205,70 @@ class RunnerTimingTests(unittest.TestCase):
             edit_seconds = _first_meaningful_edit_seconds(workspace, started_ns)
 
         self.assertEqual(edit_seconds, 0.0)
+
+    def test_collect_trace_signals_counts_behavior_markers(self) -> None:
+        with TemporaryDirectory() as tmp:
+            trace_path = Path(tmp) / "trace.jsonl"
+            entries = [
+                {"type": "agent_start"},
+                {"type": "assistant", "content": "I'll verify the route, then fix the refresh tag."},
+                {"type": "aider_log", "content": "Model output did not conform to the edit format."},
+                {"type": "aider_log", "content": "Model output did not conform to the edit format."},
+                {"type": "assistant", "content": "I'll verify the route, then fix the refresh tag."},
+            ]
+            trace_path.write_text("".join(json.dumps(entry) + "\n" for entry in entries))
+
+            signals = _collect_trace_signals(trace_path)
+
+        self.assertEqual(signals["trace_line_count"], 5)
+        self.assertEqual(signals["assistant_answer_count"], 2)
+        self.assertEqual(signals["verification_marker_count"], 2)
+        self.assertEqual(signals["self_correction_marker_count"], 2)
+        self.assertEqual(signals["format_fixation_marker_count"], 2)
+        self.assertEqual(signals["duplicate_output_attempt_count"], 2)
+
+    def test_collect_workspace_artifact_signals_summarizes_app_shape(self) -> None:
+        with TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            pyproject = workspace / "pyproject.toml"
+            pyproject.write_text(
+                "[project]\n"
+                "name='demo'\n"
+                "version='0.1.0'\n"
+                "dependencies=['flask>=3.0', 'jinja2>=3.1']\n"
+            )
+            readme = workspace / "README.md"
+            readme.write_text("before\n")
+            initial_snapshot = _workspace_file_snapshot(workspace)
+            started_ns = readme.stat().st_mtime_ns + 1_000_000
+
+            app_path = workspace / "app.py"
+            app_path.write_text(
+                "from flask import Flask, render_template_string\n"
+                "app = Flask(__name__)\n"
+                "@app.route('/')\n"
+                "def home():\n"
+                "    return render_template_string('<html><body><pre>Hello</pre></body></html>')\n"
+                "@app.route('/health')\n"
+                "def health():\n"
+                "    return 'ok'\n"
+            )
+            readme.write_text("after\n")
+            updated_ns = started_ns + 5_000_000
+            os.utime(readme, ns=(updated_ns, updated_ns))
+
+            signals = _collect_workspace_artifact_signals(workspace, initial_snapshot, started_ns)
+
+        self.assertEqual(signals["workspace_file_count"], 3)
+        self.assertEqual(signals["files_created_count"], 1)
+        self.assertEqual(signals["files_modified_count"], 1)
+        self.assertEqual(signals["dependency_count"], 2)
+        self.assertIsNotNone(signals["app_py_sha256"])
+        self.assertGreater(signals["app_py_bytes"], 0)
+        self.assertEqual(signals["app_py_loc"], 8)
+        self.assertTrue(signals["uses_render_template_string"])
+        self.assertTrue(signals["uses_inline_html"])
+        self.assertEqual(signals["route_count"], 2)
 
 
 class RunnerPropagationTests(unittest.IsolatedAsyncioTestCase):
@@ -457,3 +525,99 @@ class RunnerSummaryTimingTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNone(summary["eval_finished_at"])
         self.assertIsNone(summary["startup_seconds"])
         self.assertFalse(summary["passed"])
+
+
+class RunnerSummarySignalTests(unittest.IsolatedAsyncioTestCase):
+    async def test_run_one_writes_trace_and_artifact_signals_to_summary(self) -> None:
+        model = {"id": "gemma4:e2b", "provider": "ollama"}
+        with TemporaryDirectory() as tmp:
+            results_root = Path(tmp) / "results"
+            workspace_base = Path(tmp) / "workspaces"
+            collector = mock.Mock()
+
+            async def fake_run_agent(*args, **kwargs):
+                workspace = kwargs["workspace"]
+                trace_path = kwargs["trace_path"]
+                (workspace / "pyproject.toml").write_text(
+                    "[project]\n"
+                    "name='demo'\n"
+                    "version='0.1.0'\n"
+                    "dependencies=['flask>=3.0']\n"
+                )
+                (workspace / "app.py").write_text(
+                    "from flask import Flask, render_template_string\n"
+                    "app = Flask(__name__)\n"
+                    "@app.route('/')\n"
+                    "def home():\n"
+                    "    return render_template_string('<html><body><pre>Hello</pre></body></html>')\n"
+                )
+                trace_entries = [
+                    {"type": "agent_start"},
+                    {"type": "assistant", "content": "I'll verify this, then fix it."},
+                    {"type": "aider_log", "content": "Model output did not conform to the edit format."},
+                    {"type": "assistant", "content": "I'll verify this, then fix it."},
+                ]
+                trace_path.write_text("".join(json.dumps(entry) + "\n" for entry in trace_entries))
+                return {
+                    "finish_reason": "completed",
+                    "timed_out": False,
+                    "error": None,
+                    "agent_stop": None,
+                }
+
+            eval_result = {
+                "entry_point": "uv run python app.py",
+                "entry_point_candidates": ["uv run python app.py"],
+                "entry_point_mismatch": False,
+                "server_started": True,
+                "http_status": 200,
+                "response_bytes": 123,
+                "body_has_refresh_mechanism": True,
+                "body_has_limerick_shape": True,
+                "startup_seconds": 1.2,
+                "passed": True,
+                "error": None,
+            }
+
+            with (
+                mock.patch("benchmark.runner.RESULTS_ROOT", results_root),
+                mock.patch("benchmark.runner.WORKSPACE_BASE", workspace_base),
+                mock.patch("benchmark.runner.MetricsCollector", return_value=collector),
+                mock.patch("benchmark.runner.run_agent", side_effect=fake_run_agent),
+                mock.patch("benchmark.runner.evaluate", new=mock.AsyncMock(return_value=eval_result)),
+                mock.patch(
+                    "benchmark.runner.time.monotonic",
+                    side_effect=[10.0, 11.0, 11.0, 12.0, 12.0],
+                ),
+            ):
+                summary = await _run_one(
+                    model,
+                    "Build the app.",
+                    timeout=900,
+                    aider_stagnation_timeout=420,
+                    enable_hardware_metrics=False,
+                    job_id="20260417.083818",
+                    run_index=1,
+                    total_runs=1,
+                    round_index=1,
+                    position_in_round=1,
+                    total_rounds=1,
+                    run_dir_name="gemma4_e2b",
+                    agent_type="react",
+                    run_label="1/1:gemma4-e2b:react",
+                    task_name="limerick",
+                )
+
+        self.assertEqual(summary["trace_line_count"], 4)
+        self.assertEqual(summary["assistant_answer_count"], 2)
+        self.assertEqual(summary["verification_marker_count"], 2)
+        self.assertEqual(summary["self_correction_marker_count"], 2)
+        self.assertEqual(summary["format_fixation_marker_count"], 1)
+        self.assertEqual(summary["duplicate_output_attempt_count"], 1)
+        self.assertEqual(summary["files_created_count"], 2)
+        self.assertEqual(summary["files_modified_count"], 0)
+        self.assertEqual(summary["dependency_count"], 1)
+        self.assertTrue(summary["uses_render_template_string"])
+        self.assertTrue(summary["uses_inline_html"])
+        self.assertEqual(summary["route_count"], 1)
+        self.assertIsNotNone(summary["app_py_sha256"])


### PR DESCRIPTION
Closes #37.

## What changed
- summarize trace behavior into stable per-run counters for assistant answers, verification/self-correction markers, format-fixation markers, duplicates, and total trace lines
- snapshot the workspace so each run summary records created/modified file counts alongside `app.py` hash, size, LOC, route count, inline-html usage, and dependency count
- add helper coverage plus an end-to-end summary test that writes representative trace and workspace artifacts through `_run_one`

## Verification
- `uv run python -m unittest tests.test_runner`
- `uv run python -m unittest discover tests`